### PR TITLE
Flex gap fixes

### DIFF
--- a/csharp/tests/Facebook.Yoga/YGGapTest.cs
+++ b/csharp/tests/Facebook.Yoga/YGGapTest.cs
@@ -1411,5 +1411,233 @@ namespace Facebook.Yoga
             Assert.AreEqual(20f, root_child5.LayoutHeight);
         }
 
+        [Test]
+        public void Test_row_gap_align_items_stretch()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignContent = YogaAlign.Stretch;
+            root.Wrap = YogaWrap.Wrap;
+            root.Width = 100;
+            root.Height = 200;
+            root.ColumnGap = 10;
+            root.RowGap = 20;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 20;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.Width = 20;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode(config);
+            root_child3.Width = 20;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode(config);
+            root_child4.Width = 20;
+            root.Insert(4, root_child4);
+
+            YogaNode root_child5 = new YogaNode(config);
+            root_child5.Width = 20;
+            root.Insert(5, root_child5);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(20f, root_child0.LayoutWidth);
+            Assert.AreEqual(90f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(20f, root_child1.LayoutWidth);
+            Assert.AreEqual(90f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(20f, root_child2.LayoutWidth);
+            Assert.AreEqual(90f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(110f, root_child3.LayoutY);
+            Assert.AreEqual(20f, root_child3.LayoutWidth);
+            Assert.AreEqual(90f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child4.LayoutX);
+            Assert.AreEqual(110f, root_child4.LayoutY);
+            Assert.AreEqual(20f, root_child4.LayoutWidth);
+            Assert.AreEqual(90f, root_child4.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child5.LayoutX);
+            Assert.AreEqual(110f, root_child5.LayoutY);
+            Assert.AreEqual(20f, root_child5.LayoutWidth);
+            Assert.AreEqual(90f, root_child5.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(80f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(20f, root_child0.LayoutWidth);
+            Assert.AreEqual(90f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(20f, root_child1.LayoutWidth);
+            Assert.AreEqual(90f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(20f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(20f, root_child2.LayoutWidth);
+            Assert.AreEqual(90f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(80f, root_child3.LayoutX);
+            Assert.AreEqual(110f, root_child3.LayoutY);
+            Assert.AreEqual(20f, root_child3.LayoutWidth);
+            Assert.AreEqual(90f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child4.LayoutX);
+            Assert.AreEqual(110f, root_child4.LayoutY);
+            Assert.AreEqual(20f, root_child4.LayoutWidth);
+            Assert.AreEqual(90f, root_child4.LayoutHeight);
+
+            Assert.AreEqual(20f, root_child5.LayoutX);
+            Assert.AreEqual(110f, root_child5.LayoutY);
+            Assert.AreEqual(20f, root_child5.LayoutWidth);
+            Assert.AreEqual(90f, root_child5.LayoutHeight);
+        }
+
+        [Test]
+        public void Test_row_gap_align_items_end()
+        {
+            YogaConfig config = new YogaConfig();
+
+            YogaNode root = new YogaNode(config);
+            root.FlexDirection = YogaFlexDirection.Row;
+            root.AlignItems = YogaAlign.FlexEnd;
+            root.Wrap = YogaWrap.Wrap;
+            root.Width = 100;
+            root.Height = 200;
+            root.ColumnGap = 10;
+            root.RowGap = 20;
+
+            YogaNode root_child0 = new YogaNode(config);
+            root_child0.Width = 20;
+            root.Insert(0, root_child0);
+
+            YogaNode root_child1 = new YogaNode(config);
+            root_child1.Width = 20;
+            root.Insert(1, root_child1);
+
+            YogaNode root_child2 = new YogaNode(config);
+            root_child2.Width = 20;
+            root.Insert(2, root_child2);
+
+            YogaNode root_child3 = new YogaNode(config);
+            root_child3.Width = 20;
+            root.Insert(3, root_child3);
+
+            YogaNode root_child4 = new YogaNode(config);
+            root_child4.Width = 20;
+            root.Insert(4, root_child4);
+
+            YogaNode root_child5 = new YogaNode(config);
+            root_child5.Width = 20;
+            root.Insert(5, root_child5);
+            root.StyleDirection = YogaDirection.LTR;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(20f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(20f, root_child1.LayoutWidth);
+            Assert.AreEqual(0f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(20f, root_child2.LayoutWidth);
+            Assert.AreEqual(0f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(0f, root_child3.LayoutX);
+            Assert.AreEqual(20f, root_child3.LayoutY);
+            Assert.AreEqual(20f, root_child3.LayoutWidth);
+            Assert.AreEqual(0f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(30f, root_child4.LayoutX);
+            Assert.AreEqual(20f, root_child4.LayoutY);
+            Assert.AreEqual(20f, root_child4.LayoutWidth);
+            Assert.AreEqual(0f, root_child4.LayoutHeight);
+
+            Assert.AreEqual(60f, root_child5.LayoutX);
+            Assert.AreEqual(20f, root_child5.LayoutY);
+            Assert.AreEqual(20f, root_child5.LayoutWidth);
+            Assert.AreEqual(0f, root_child5.LayoutHeight);
+
+            root.StyleDirection = YogaDirection.RTL;
+            root.CalculateLayout();
+
+            Assert.AreEqual(0f, root.LayoutX);
+            Assert.AreEqual(0f, root.LayoutY);
+            Assert.AreEqual(100f, root.LayoutWidth);
+            Assert.AreEqual(200f, root.LayoutHeight);
+
+            Assert.AreEqual(80f, root_child0.LayoutX);
+            Assert.AreEqual(0f, root_child0.LayoutY);
+            Assert.AreEqual(20f, root_child0.LayoutWidth);
+            Assert.AreEqual(0f, root_child0.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child1.LayoutX);
+            Assert.AreEqual(0f, root_child1.LayoutY);
+            Assert.AreEqual(20f, root_child1.LayoutWidth);
+            Assert.AreEqual(0f, root_child1.LayoutHeight);
+
+            Assert.AreEqual(20f, root_child2.LayoutX);
+            Assert.AreEqual(0f, root_child2.LayoutY);
+            Assert.AreEqual(20f, root_child2.LayoutWidth);
+            Assert.AreEqual(0f, root_child2.LayoutHeight);
+
+            Assert.AreEqual(80f, root_child3.LayoutX);
+            Assert.AreEqual(20f, root_child3.LayoutY);
+            Assert.AreEqual(20f, root_child3.LayoutWidth);
+            Assert.AreEqual(0f, root_child3.LayoutHeight);
+
+            Assert.AreEqual(50f, root_child4.LayoutX);
+            Assert.AreEqual(20f, root_child4.LayoutY);
+            Assert.AreEqual(20f, root_child4.LayoutWidth);
+            Assert.AreEqual(0f, root_child4.LayoutHeight);
+
+            Assert.AreEqual(20f, root_child5.LayoutX);
+            Assert.AreEqual(20f, root_child5.LayoutY);
+            Assert.AreEqual(20f, root_child5.LayoutWidth);
+            Assert.AreEqual(0f, root_child5.LayoutHeight);
+        }
+
     }
 }

--- a/gentest/fixtures/YGGapTest.html
+++ b/gentest/fixtures/YGGapTest.html
@@ -108,3 +108,23 @@
   <div style="width: 20px; height: 20px"></div>
   <div style="width: 20px; height: 20px"></div>
 </div>
+
+<div id="row_gap_align_items_stretch" style="flex-direction: row; flex-wrap: wrap; width: 100px; height: 200px; column-gap: 10px; row-gap: 20px; align-items:stretch; align-content: stretch">
+  <div style="width: 20px; "></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+</div>
+
+
+<div id="row_gap_align_items_end" style="flex-direction: row; flex-wrap: wrap; width: 100px; height: 200px; column-gap: 10px; row-gap: 20px; align-items:flex-end;">
+  <div style="width: 20px; "></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+  <div style="width: 20px;"></div>
+</div>
+

--- a/java/tests/com/facebook/yoga/YGGapTest.java
+++ b/java/tests/com/facebook/yoga/YGGapTest.java
@@ -1405,6 +1405,232 @@ public class YGGapTest {
     assertEquals(20f, root_child5.getLayoutHeight(), 0.0f);
   }
 
+  @Test
+  public void test_row_gap_align_items_stretch() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignContent(YogaAlign.STRETCH);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(100f);
+    root.setHeight(200f);
+    root.setGap(YogaGap.COLUMN, 10f);
+    root.setGap(YogaGap.ROW, 20f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(20f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setWidth(20f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = createNode(config);
+    root_child3.setWidth(20f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = createNode(config);
+    root_child4.setWidth(20f);
+    root.addChildAt(root_child4, 4);
+
+    final YogaNode root_child5 = createNode(config);
+    root_child5.setWidth(20f);
+    root.addChildAt(root_child5, 5);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child4.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child5.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child5.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child5.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child5.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child4.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child5.getLayoutX(), 0.0f);
+    assertEquals(110f, root_child5.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child5.getLayoutWidth(), 0.0f);
+    assertEquals(90f, root_child5.getLayoutHeight(), 0.0f);
+  }
+
+  @Test
+  public void test_row_gap_align_items_end() {
+    YogaConfig config = YogaConfigFactory.create();
+
+    final YogaNode root = createNode(config);
+    root.setFlexDirection(YogaFlexDirection.ROW);
+    root.setAlignItems(YogaAlign.FLEX_END);
+    root.setWrap(YogaWrap.WRAP);
+    root.setWidth(100f);
+    root.setHeight(200f);
+    root.setGap(YogaGap.COLUMN, 10f);
+    root.setGap(YogaGap.ROW, 20f);
+
+    final YogaNode root_child0 = createNode(config);
+    root_child0.setWidth(20f);
+    root.addChildAt(root_child0, 0);
+
+    final YogaNode root_child1 = createNode(config);
+    root_child1.setWidth(20f);
+    root.addChildAt(root_child1, 1);
+
+    final YogaNode root_child2 = createNode(config);
+    root_child2.setWidth(20f);
+    root.addChildAt(root_child2, 2);
+
+    final YogaNode root_child3 = createNode(config);
+    root_child3.setWidth(20f);
+    root.addChildAt(root_child3, 3);
+
+    final YogaNode root_child4 = createNode(config);
+    root_child4.setWidth(20f);
+    root.addChildAt(root_child4, 4);
+
+    final YogaNode root_child5 = createNode(config);
+    root_child5.setWidth(20f);
+    root.addChildAt(root_child5, 5);
+    root.setDirection(YogaDirection.LTR);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(0f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(30f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutHeight(), 0.0f);
+
+    assertEquals(60f, root_child5.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child5.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child5.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child5.getLayoutHeight(), 0.0f);
+
+    root.setDirection(YogaDirection.RTL);
+    root.calculateLayout(YogaConstants.UNDEFINED, YogaConstants.UNDEFINED);
+
+    assertEquals(0f, root.getLayoutX(), 0.0f);
+    assertEquals(0f, root.getLayoutY(), 0.0f);
+    assertEquals(100f, root.getLayoutWidth(), 0.0f);
+    assertEquals(200f, root.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child0.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child0.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child0.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child1.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child1.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child1.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child2.getLayoutX(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child2.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child2.getLayoutHeight(), 0.0f);
+
+    assertEquals(80f, root_child3.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child3.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child3.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child3.getLayoutHeight(), 0.0f);
+
+    assertEquals(50f, root_child4.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child4.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child4.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child4.getLayoutHeight(), 0.0f);
+
+    assertEquals(20f, root_child5.getLayoutX(), 0.0f);
+    assertEquals(20f, root_child5.getLayoutY(), 0.0f);
+    assertEquals(20f, root_child5.getLayoutWidth(), 0.0f);
+    assertEquals(0f, root_child5.getLayoutHeight(), 0.0f);
+  }
+
   private YogaNode createNode(YogaConfig config) {
     return mNodeFactory.create(config);
   }

--- a/javascript/tests/Facebook.Yoga/YGGapTest.js
+++ b/javascript/tests/Facebook.Yoga/YGGapTest.js
@@ -1450,3 +1450,237 @@ it("column_gap_wrap_align_space_around", function () {
     config.free();
   }
 });
+it("row_gap_align_items_stretch", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignContent(Yoga.ALIGN_STRETCH);
+    root.setFlexWrap(Yoga.WRAP_WRAP);
+    root.setWidth(100);
+    root.setHeight(200);
+    root.setGap(Yoga.GAP_COLUMN, 10);
+    root.setGap(Yoga.GAP_ROW, 20);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(20);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(20);
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(20);
+    root.insertChild(root_child2, 2);
+
+    var root_child3 = Yoga.Node.create(config);
+    root_child3.setWidth(20);
+    root.insertChild(root_child3, 3);
+
+    var root_child4 = Yoga.Node.create(config);
+    root_child4.setWidth(20);
+    root.insertChild(root_child4, 4);
+
+    var root_child5 = Yoga.Node.create(config);
+    root_child5.setWidth(20);
+    root.insertChild(root_child5, 5);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(20 === root_child0.getComputedWidth(), "20 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(90 === root_child0.getComputedHeight(), "90 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(30 === root_child1.getComputedLeft(), "30 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(20 === root_child1.getComputedWidth(), "20 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(90 === root_child1.getComputedHeight(), "90 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(60 === root_child2.getComputedLeft(), "60 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(20 === root_child2.getComputedWidth(), "20 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(90 === root_child2.getComputedHeight(), "90 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+    console.assert(110 === root_child3.getComputedTop(), "110 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+    console.assert(20 === root_child3.getComputedWidth(), "20 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+    console.assert(90 === root_child3.getComputedHeight(), "90 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+    console.assert(30 === root_child4.getComputedLeft(), "30 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+    console.assert(110 === root_child4.getComputedTop(), "110 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+    console.assert(20 === root_child4.getComputedWidth(), "20 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+    console.assert(90 === root_child4.getComputedHeight(), "90 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+    console.assert(60 === root_child5.getComputedLeft(), "60 === root_child5.getComputedLeft() (" + root_child5.getComputedLeft() + ")");
+    console.assert(110 === root_child5.getComputedTop(), "110 === root_child5.getComputedTop() (" + root_child5.getComputedTop() + ")");
+    console.assert(20 === root_child5.getComputedWidth(), "20 === root_child5.getComputedWidth() (" + root_child5.getComputedWidth() + ")");
+    console.assert(90 === root_child5.getComputedHeight(), "90 === root_child5.getComputedHeight() (" + root_child5.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(80 === root_child0.getComputedLeft(), "80 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(20 === root_child0.getComputedWidth(), "20 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(90 === root_child0.getComputedHeight(), "90 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(20 === root_child1.getComputedWidth(), "20 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(90 === root_child1.getComputedHeight(), "90 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(20 === root_child2.getComputedLeft(), "20 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(20 === root_child2.getComputedWidth(), "20 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(90 === root_child2.getComputedHeight(), "90 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    console.assert(80 === root_child3.getComputedLeft(), "80 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+    console.assert(110 === root_child3.getComputedTop(), "110 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+    console.assert(20 === root_child3.getComputedWidth(), "20 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+    console.assert(90 === root_child3.getComputedHeight(), "90 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+    console.assert(50 === root_child4.getComputedLeft(), "50 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+    console.assert(110 === root_child4.getComputedTop(), "110 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+    console.assert(20 === root_child4.getComputedWidth(), "20 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+    console.assert(90 === root_child4.getComputedHeight(), "90 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+    console.assert(20 === root_child5.getComputedLeft(), "20 === root_child5.getComputedLeft() (" + root_child5.getComputedLeft() + ")");
+    console.assert(110 === root_child5.getComputedTop(), "110 === root_child5.getComputedTop() (" + root_child5.getComputedTop() + ")");
+    console.assert(20 === root_child5.getComputedWidth(), "20 === root_child5.getComputedWidth() (" + root_child5.getComputedWidth() + ")");
+    console.assert(90 === root_child5.getComputedHeight(), "90 === root_child5.getComputedHeight() (" + root_child5.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});
+it("row_gap_align_items_end", function () {
+  var config = Yoga.Config.create();
+
+  try {
+    var root = Yoga.Node.create(config);
+    root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+    root.setAlignItems(Yoga.ALIGN_FLEX_END);
+    root.setFlexWrap(Yoga.WRAP_WRAP);
+    root.setWidth(100);
+    root.setHeight(200);
+    root.setGap(Yoga.GAP_COLUMN, 10);
+    root.setGap(Yoga.GAP_ROW, 20);
+
+    var root_child0 = Yoga.Node.create(config);
+    root_child0.setWidth(20);
+    root.insertChild(root_child0, 0);
+
+    var root_child1 = Yoga.Node.create(config);
+    root_child1.setWidth(20);
+    root.insertChild(root_child1, 1);
+
+    var root_child2 = Yoga.Node.create(config);
+    root_child2.setWidth(20);
+    root.insertChild(root_child2, 2);
+
+    var root_child3 = Yoga.Node.create(config);
+    root_child3.setWidth(20);
+    root.insertChild(root_child3, 3);
+
+    var root_child4 = Yoga.Node.create(config);
+    root_child4.setWidth(20);
+    root.insertChild(root_child4, 4);
+
+    var root_child5 = Yoga.Node.create(config);
+    root_child5.setWidth(20);
+    root.insertChild(root_child5, 5);
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(0 === root_child0.getComputedLeft(), "0 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(20 === root_child0.getComputedWidth(), "20 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(30 === root_child1.getComputedLeft(), "30 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(20 === root_child1.getComputedWidth(), "20 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(0 === root_child1.getComputedHeight(), "0 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(60 === root_child2.getComputedLeft(), "60 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(20 === root_child2.getComputedWidth(), "20 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(0 === root_child2.getComputedHeight(), "0 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    console.assert(0 === root_child3.getComputedLeft(), "0 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child3.getComputedTop(), "20 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+    console.assert(20 === root_child3.getComputedWidth(), "20 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+    console.assert(0 === root_child3.getComputedHeight(), "0 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+    console.assert(30 === root_child4.getComputedLeft(), "30 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+    console.assert(20 === root_child4.getComputedTop(), "20 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+    console.assert(20 === root_child4.getComputedWidth(), "20 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+    console.assert(0 === root_child4.getComputedHeight(), "0 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+    console.assert(60 === root_child5.getComputedLeft(), "60 === root_child5.getComputedLeft() (" + root_child5.getComputedLeft() + ")");
+    console.assert(20 === root_child5.getComputedTop(), "20 === root_child5.getComputedTop() (" + root_child5.getComputedTop() + ")");
+    console.assert(20 === root_child5.getComputedWidth(), "20 === root_child5.getComputedWidth() (" + root_child5.getComputedWidth() + ")");
+    console.assert(0 === root_child5.getComputedHeight(), "0 === root_child5.getComputedHeight() (" + root_child5.getComputedHeight() + ")");
+
+    root.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_RTL);
+
+    console.assert(0 === root.getComputedLeft(), "0 === root.getComputedLeft() (" + root.getComputedLeft() + ")");
+    console.assert(0 === root.getComputedTop(), "0 === root.getComputedTop() (" + root.getComputedTop() + ")");
+    console.assert(100 === root.getComputedWidth(), "100 === root.getComputedWidth() (" + root.getComputedWidth() + ")");
+    console.assert(200 === root.getComputedHeight(), "200 === root.getComputedHeight() (" + root.getComputedHeight() + ")");
+
+    console.assert(80 === root_child0.getComputedLeft(), "80 === root_child0.getComputedLeft() (" + root_child0.getComputedLeft() + ")");
+    console.assert(0 === root_child0.getComputedTop(), "0 === root_child0.getComputedTop() (" + root_child0.getComputedTop() + ")");
+    console.assert(20 === root_child0.getComputedWidth(), "20 === root_child0.getComputedWidth() (" + root_child0.getComputedWidth() + ")");
+    console.assert(0 === root_child0.getComputedHeight(), "0 === root_child0.getComputedHeight() (" + root_child0.getComputedHeight() + ")");
+
+    console.assert(50 === root_child1.getComputedLeft(), "50 === root_child1.getComputedLeft() (" + root_child1.getComputedLeft() + ")");
+    console.assert(0 === root_child1.getComputedTop(), "0 === root_child1.getComputedTop() (" + root_child1.getComputedTop() + ")");
+    console.assert(20 === root_child1.getComputedWidth(), "20 === root_child1.getComputedWidth() (" + root_child1.getComputedWidth() + ")");
+    console.assert(0 === root_child1.getComputedHeight(), "0 === root_child1.getComputedHeight() (" + root_child1.getComputedHeight() + ")");
+
+    console.assert(20 === root_child2.getComputedLeft(), "20 === root_child2.getComputedLeft() (" + root_child2.getComputedLeft() + ")");
+    console.assert(0 === root_child2.getComputedTop(), "0 === root_child2.getComputedTop() (" + root_child2.getComputedTop() + ")");
+    console.assert(20 === root_child2.getComputedWidth(), "20 === root_child2.getComputedWidth() (" + root_child2.getComputedWidth() + ")");
+    console.assert(0 === root_child2.getComputedHeight(), "0 === root_child2.getComputedHeight() (" + root_child2.getComputedHeight() + ")");
+
+    console.assert(80 === root_child3.getComputedLeft(), "80 === root_child3.getComputedLeft() (" + root_child3.getComputedLeft() + ")");
+    console.assert(20 === root_child3.getComputedTop(), "20 === root_child3.getComputedTop() (" + root_child3.getComputedTop() + ")");
+    console.assert(20 === root_child3.getComputedWidth(), "20 === root_child3.getComputedWidth() (" + root_child3.getComputedWidth() + ")");
+    console.assert(0 === root_child3.getComputedHeight(), "0 === root_child3.getComputedHeight() (" + root_child3.getComputedHeight() + ")");
+
+    console.assert(50 === root_child4.getComputedLeft(), "50 === root_child4.getComputedLeft() (" + root_child4.getComputedLeft() + ")");
+    console.assert(20 === root_child4.getComputedTop(), "20 === root_child4.getComputedTop() (" + root_child4.getComputedTop() + ")");
+    console.assert(20 === root_child4.getComputedWidth(), "20 === root_child4.getComputedWidth() (" + root_child4.getComputedWidth() + ")");
+    console.assert(0 === root_child4.getComputedHeight(), "0 === root_child4.getComputedHeight() (" + root_child4.getComputedHeight() + ")");
+
+    console.assert(20 === root_child5.getComputedLeft(), "20 === root_child5.getComputedLeft() (" + root_child5.getComputedLeft() + ")");
+    console.assert(20 === root_child5.getComputedTop(), "20 === root_child5.getComputedTop() (" + root_child5.getComputedTop() + ")");
+    console.assert(20 === root_child5.getComputedWidth(), "20 === root_child5.getComputedWidth() (" + root_child5.getComputedWidth() + ")");
+    console.assert(0 === root_child5.getComputedHeight(), "0 === root_child5.getComputedHeight() (" + root_child5.getComputedHeight() + ")");
+  } finally {
+    if (typeof root !== "undefined") {
+      root.freeRecursive();
+    }
+
+    config.free();
+  }
+});

--- a/tests/YGGapTest.cpp
+++ b/tests/YGGapTest.cpp
@@ -1405,3 +1405,231 @@ TEST(YogaTest, column_gap_wrap_align_space_around) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, row_gap_align_items_stretch) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignContent(root, YGAlignStretch);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 200);
+  YGNodeStyleSetGap(root, YGGapColumn, 10);
+  YGNodeStyleSetGap(root, YGGapRow, 20);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 20);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 20);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child3, 20);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child4, 20);
+  YGNodeInsertChild(root, root_child4, 4);
+
+  const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child5, 20);
+  YGNodeInsertChild(root, root_child5, 5);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child4));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child5));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child5));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child5));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child5));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child4));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child5));
+  ASSERT_FLOAT_EQ(110, YGNodeLayoutGetTop(root_child5));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child5));
+  ASSERT_FLOAT_EQ(90, YGNodeLayoutGetHeight(root_child5));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}
+
+TEST(YogaTest, row_gap_align_items_end) {
+  const YGConfigRef config = YGConfigNew();
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+  YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+  YGNodeStyleSetAlignItems(root, YGAlignFlexEnd);
+  YGNodeStyleSetFlexWrap(root, YGWrapWrap);
+  YGNodeStyleSetWidth(root, 100);
+  YGNodeStyleSetHeight(root, 200);
+  YGNodeStyleSetGap(root, YGGapColumn, 10);
+  YGNodeStyleSetGap(root, YGGapRow, 20);
+
+  const YGNodeRef root_child0 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child0, 20);
+  YGNodeInsertChild(root, root_child0, 0);
+
+  const YGNodeRef root_child1 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child1, 20);
+  YGNodeInsertChild(root, root_child1, 1);
+
+  const YGNodeRef root_child2 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child2, 20);
+  YGNodeInsertChild(root, root_child2, 2);
+
+  const YGNodeRef root_child3 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child3, 20);
+  YGNodeInsertChild(root, root_child3, 3);
+
+  const YGNodeRef root_child4 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child4, 20);
+  YGNodeInsertChild(root, root_child4, 4);
+
+  const YGNodeRef root_child5 = YGNodeNewWithConfig(config);
+  YGNodeStyleSetWidth(root_child5, 20);
+  YGNodeInsertChild(root, root_child5, 5);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(30, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child4));
+
+  ASSERT_FLOAT_EQ(60, YGNodeLayoutGetLeft(root_child5));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child5));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child5));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child5));
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionRTL);
+
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetLeft(root));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root));
+  ASSERT_FLOAT_EQ(100, YGNodeLayoutGetWidth(root));
+  ASSERT_FLOAT_EQ(200, YGNodeLayoutGetHeight(root));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child0));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child0));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child0));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child1));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child1));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child1));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetTop(root_child2));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child2));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child2));
+
+  ASSERT_FLOAT_EQ(80, YGNodeLayoutGetLeft(root_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child3));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child3));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child3));
+
+  ASSERT_FLOAT_EQ(50, YGNodeLayoutGetLeft(root_child4));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child4));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child4));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child4));
+
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetLeft(root_child5));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetTop(root_child5));
+  ASSERT_FLOAT_EQ(20, YGNodeLayoutGetWidth(root_child5));
+  ASSERT_FLOAT_EQ(0, YGNodeLayoutGetHeight(root_child5));
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -3247,7 +3247,7 @@ static void YGNodelayoutImpl(
   // STEP 8: MULTI-LINE CONTENT ALIGNMENT
   // currentLead stores the size of the cross dim
   if (performLayout && (isNodeFlexWrap || YGIsBaselineLayout(node))) {
-    float crossDimLead = crossAxisGap;
+    float crossDimLead = 0;
     float currentLead = leadingPaddingAndBorderCross;
     if (!YGFloatIsUndefined(availableInnerCrossDim)) {
       const float remainingAlignContentDim =
@@ -3261,14 +3261,14 @@ static void YGNodelayoutImpl(
           break;
         case YGAlignStretch:
           if (availableInnerCrossDim > totalLineCrossDim) {
-            crossDimLead += remainingAlignContentDim / lineCount;
+            crossDimLead = remainingAlignContentDim / lineCount;
           }
           break;
         case YGAlignSpaceAround:
           if (availableInnerCrossDim > totalLineCrossDim) {
             currentLead += remainingAlignContentDim / (2 * lineCount);
             if (lineCount > 1) {
-              crossDimLead += remainingAlignContentDim / lineCount;
+              crossDimLead = remainingAlignContentDim / lineCount;
             }
           } else {
             currentLead += remainingAlignContentDim / 2;
@@ -3276,7 +3276,7 @@ static void YGNodelayoutImpl(
           break;
         case YGAlignSpaceBetween:
           if (availableInnerCrossDim > totalLineCrossDim && lineCount > 1) {
-            crossDimLead += remainingAlignContentDim / (lineCount - 1);
+            crossDimLead = remainingAlignContentDim / (lineCount - 1);
           }
           break;
         case YGAlignAuto:
@@ -3334,7 +3334,8 @@ static void YGNodelayoutImpl(
       }
       endIndex = ii;
       lineHeight += crossDimLead;
-
+      currentLead += i != 0 ? crossAxisGap : 0;
+        
       if (performLayout) {
         for (ii = startIndex; ii < endIndex; ii++) {
           const YGNodeRef child = node->getChild(ii);


### PR DESCRIPTION
Added some test cases for align-items stretch and align-content stretch.

## Issue
Current cross offset for gap is handled using crossDimLead, it can create issues for cases when lineHeight is being used to generate the height. e.g. in align-items stretch.

## Approach
Removed logic to mutate the lineHeight and add cross offset using currentLead instead of crossDimLead.

P.S. I know this already existed but lineHeight is confusing word! Here it means flexLineHeight but when I hear lineHeight, i often think about text line height 😓